### PR TITLE
Fix prop type of component in AuthenticatedRoute

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ AuthenticatedRoute.propTypes = {
 	...Route.PropTypes,
 	isAuthenticated: PropTypes.bool.isRequired,
 	redirectTo: PropTypes.string,
-	component: PropTypes.element,
+	component: PropTypes.func,
 	loginPath: PropTypes.string,
 	children: PropTypes.node
 };


### PR DESCRIPTION
According  to the docs `<AuthenticatedRoute>`'s prop `component` expects a React component (not an element), **which is and behaves correct**.
But in the prop types it's wrongly defined as element.
Therefor the type checks correctly throw a warning that it expects an element (which is wrong and doesn't behave correct).

> index.js:2178 Warning: Failed prop type: Invalid prop `component` of type `function` supplied to `AuthenticatedRoute`, expected a single ReactElement.
>     in AuthenticatedRoute (at App.js:24)
>     in App (at index.js:8)

Changing the prop type to `func` is the correct choice and fixes the warning.