### PR TITLE
Add 'babel-preset-env' module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"babel-cli": "^6.26.0",
 		"babel-eslint": "^8.0.3",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+		"babel-preset-env": "^1.6.1",
 		"babel-preset-react": "^6.24.1",
 		"babel-preset-stage-3": "^6.24.1",
 		"xo": "*"
@@ -67,6 +68,7 @@
 			"transform-es2015-modules-commonjs"
 		],
 		"presets": [
+			"env",
 			"react",
 			"stage-3"
 		]


### PR DESCRIPTION
Using the facebook/create-react-app scripts to create a production build for a React app is throwing an error:
```
Failed to minify the code from this file:

 	./node_modules/react-router-util/dist/index.js:29
```

By adding the `babel-preset-env` all ES6 features are compiled down to ES5, which allows removes the above error and allows the file to be minified.
