### PR TITLE
Render ConditionalRoute component with props using RouteWithProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,16 +85,16 @@ AuthenticatedRoute.propTypes = {
 };
 
 export const ConditionalRoute = ({
-  conditional,
-  trueComponent: True,
-  falseComponent: False,
-  trueRedirectTo,
-  falseRedirectTo,
-  ...rest
+	conditional,
+	trueComponent: True,
+	falseComponent: False,
+	trueRedirectTo,
+	falseRedirectTo,
+	...rest
 }) => {
-  return conditional
-	 ? (True ? <RouteWithProps component={True} {...rest}/> : <Redirect to={trueRedirectTo}/>)
-	 : (False ? <RouteWithProps component={False} {...rest}/> : <Redirect to={falseRedirectTo}/>);
+	return conditional ?
+		(True ? <RouteWithProps component={True} {...rest}/> : <Redirect to={trueRedirectTo}/>) :
+		(False ? <RouteWithProps component={False} {...rest}/> : <Redirect to={falseRedirectTo}/>);
 };
 
 export const BackLink = withRouter(({history, children, ...rest}) => {

--- a/index.js
+++ b/index.js
@@ -85,21 +85,16 @@ AuthenticatedRoute.propTypes = {
 };
 
 export const ConditionalRoute = ({
-	conditional,
-	trueComponent: True,
-	falseComponent: False,
-	trueRedirectTo,
-	falseRedirectTo,
-	...rest
+  conditional,
+  trueComponent: True,
+  falseComponent: False,
+  trueRedirectTo,
+  falseRedirectTo,
+  ...rest
 }) => {
-	let ret;
-	if (conditional) {
-		ret = True ? <True/> : <Redirect to={trueRedirectTo}/>;
-	} else {
-		ret = False ? <False/> : <Redirect to={falseRedirectTo}/>;
-	}
-
-	return <Route render={() => ret} {...rest}/>;
+  return conditional
+	 ? (True ? <RouteWithProps component={True} {...rest}/> : <Redirect to={trueRedirectTo}/>)
+	 : (False ? <RouteWithProps component={False} {...rest}/> : <Redirect to={falseRedirectTo}/>);
 };
 
 export const BackLink = withRouter(({history, children, ...rest}) => {


### PR DESCRIPTION
This fix is rendering the true and false `ConditionalRoute` components with all the props included using the `RouteWithProps` util in this module.

Currently, in the use case of having a URL parameter the `match` object of `react-router` is not being passed to the rendered component. 

E.g.
```
<ConditionalRoute
    conditional={ isUserLoggedInConditional }
    trueComponent={ User }
    falseRedirectTo="/login"
    path="/user/:id" 
/>
```

By rendering the `User` component with `RouteWithProps`, all the props from `react-router` are passed down to the component when rendered. That way, in the `User` component `this.props.match` can be accessed.