### PR TITLE
Pass react-router props to ConditionalRoute components

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,13 +93,13 @@ export const ConditionalRoute = ({
 	...rest
 }) => {
 	if (conditional) {
-		return True
-			? <Route render={(props) => <True {...props} />} {...rest}/>
-			: <Route render={() => <Redirect to={trueRedirectTo}/>} {...rest}/>;
+		return True ?
+			<Route render={props => <True {...props} />} {...rest}/> :
+			<Route render={() => <Redirect to={trueRedirectTo}/>} {...rest}/>;
 	}
-	return False
-		? <Route render={(props) => <False {...props} />} {...rest}/>
-		: <Route render={() => <Redirect to={falseRedirectTo}/>} {...rest}/>;
+	return False ?
+		<Route render={props => <False {...props} />} {...rest}/> :
+		<Route render={() => <Redirect to={falseRedirectTo}/>} {...rest}/>;
 };
 
 export const BackLink = withRouter(({history, children, ...rest}) => {

--- a/index.js
+++ b/index.js
@@ -94,11 +94,12 @@ export const ConditionalRoute = ({
 }) => {
 	if (conditional) {
 		return True ?
-			<Route render={props => <True {...props} />} {...rest}/> :
+			<Route render={props => <True {...props}/>} {...rest}/> :
 			<Route render={() => <Redirect to={trueRedirectTo}/>} {...rest}/>;
 	}
+
 	return False ?
-		<Route render={props => <False {...props} />} {...rest}/> :
+		<Route render={props => <False {...props}/>} {...rest}/> :
 		<Route render={() => <Redirect to={falseRedirectTo}/>} {...rest}/>;
 };
 

--- a/index.js
+++ b/index.js
@@ -92,14 +92,14 @@ export const ConditionalRoute = ({
 	falseRedirectTo,
 	...rest
 }) => {
-	let ret;
 	if (conditional) {
-		ret = True ? <True/> : <Redirect to={trueRedirectTo}/>;
-	} else {
-		ret = False ? <False/> : <Redirect to={falseRedirectTo}/>;
+		return True
+			? <Route render={(props) => <True {...props} />} {...rest}/>
+			: <Route render={() => <Redirect to={trueRedirectTo}/>} {...rest}/>;
 	}
-
-	return <Route render={() => ret} {...rest}/>;
+	return False
+		? <Route render={(props) => <False {...props} />} {...rest}/>
+		: <Route render={() => <Redirect to={falseRedirectTo}/>} {...rest}/>;
 };
 
 export const BackLink = withRouter(({history, children, ...rest}) => {


### PR DESCRIPTION
When using a ConditionalRoute component and trying to set a path to `/path/to/:id`, then the parameter isn't being passed to the component.

This change passes the required props down to the component which can then be accesses through `this.props.match`.