### PR TITLE
Add nested routes support to `AuthenticatedRoute`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ import {
 	Route,
 	Redirect,
 	Link,
-	withRouter
+	withRouter,
+	matchPath
 } from 'react-router-dom';
 import {createBrowserHistory, createMemoryHistory} from 'history';
 
@@ -64,9 +65,13 @@ export const AuthenticatedRoute = ({
 }) => {
 	const children = rest.children || null;
 
+	const {path, exact} = rest;
+
 	if (!isAuthenticated) {
-		// TODO: `history.location.pathname` probably doesn't work with nested routes
-		const redirect = to => to === history.location.pathname.replace(/\b\/.*$/, '') ? children : <Redirect to={to}/>;
+		const redirect = to => matchPath(to, {
+			path,
+			exact
+		}) ? children : <Redirect to={to}/>;
 
 		return redirect(loginPath);
 	}

--- a/index.js
+++ b/index.js
@@ -68,11 +68,7 @@ export const AuthenticatedRoute = ({
 	const {path, exact} = rest;
 
 	if (!isAuthenticated) {
-		const redirect = to => matchPath(to, {
-			path,
-			exact
-		}) ? children : <Redirect to={to}/>;
-
+		const redirect = to => matchPath(to, {path, exact}) ? children : <Redirect to={to}/>;
 		return redirect(loginPath);
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,17 @@ Yet another example:
 </AuthenticatedRoute>
 ```
 
+Example with nested routes: 
+```jsx
+<AuthenticatedRoute path="/dashboard/:nested" isAuthenticated={this.state.isLoggedIn}>
+	<Switch>
+		<RouteWithProps path="/information" component={Login} {...this.state}/>
+		<RouteWithProps path="/contact" component={Main} {...this.state}/>
+	</Switch>
+</AuthenticatedRoute>
+```
+When using nested routes, the `:nested` value must be specified in the outer route so that [`matchPath`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md) can map it to the correct nested route (`/information` and `/contact` in this case).
+
 ### `<ConditionalRoute/>`
 
 A conditional version of [`<Route/>`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/Route.md). You pass it a `conditional` prop with a boolean. If it's truthy, either the given `trueComponent` will be rendered or it will redirect to `trueRedirectTo`. If it's falsy, either the given `falseComponent` will be rendered or it will redirect to `trueRedirectTo`. It accepts all the props `<Route/>` accepts except for `render`.

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,8 @@ Yet another example:
 </AuthenticatedRoute>
 ```
 
-Example with nested routes: 
+Example with nested routes:
+
 ```jsx
 <AuthenticatedRoute path="/dashboard/:nested" isAuthenticated={this.state.isLoggedIn}>
 	<Switch>
@@ -130,6 +131,7 @@ Example with nested routes:
 	</Switch>
 </AuthenticatedRoute>
 ```
+
 When using nested routes, the `:nested` value must be specified in the outer route so that [`matchPath`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md) can map it to the correct nested route (`/information` and `/contact` in this case).
 
 ### `<ConditionalRoute/>`

--- a/readme.md
+++ b/readme.md
@@ -125,8 +125,8 @@ Example with nested routes:
 ```jsx
 <AuthenticatedRoute path="/dashboard/:nested" isAuthenticated={this.state.isLoggedIn}>
 	<Switch>
-		<RouteWithProps path="/information" component={Login} {...this.state}/>
-		<RouteWithProps path="/contact" component={Main} {...this.state}/>
+		<RouteWithProps path="/information" component={Information} {...this.state}/>
+		<RouteWithProps path="/contact" component={Contact} {...this.state}/>
 	</Switch>
 </AuthenticatedRoute>
 ```

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -2,8 +2,8 @@ import test from 'ava';
 import React from 'react';
 import {Route} from 'react-router-dom';
 import {createBrowserHistory} from 'history';
-import {render} from 'enzyme';
-import {App} from './fixtures/app';
+import {render, mount} from 'enzyme';
+import {App, Login} from './fixtures/app';
 
 test('creates a browser history', t => {
 	const {history} = require('../index');
@@ -38,4 +38,73 @@ test('accepts custom history object', t => {
 
 	const wrapper = render(<BrowserComponent history={history}/>);
 	t.true(wrapper.text().includes('42'));
+});
+
+test('allows access to specified path if authenticated', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	history.location.pathname = '/about';
+	const isAuthenticated = true;
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					path="/about"
+					isAuthenticated={isAuthenticated}
+					component={App}
+				/>
+				<Login/>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent history={history}/>);
+
+	t.true(wrapper.text().includes('ABOUT'));
+});
+
+test('redirects to /login if not authenticated', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	history.location.pathname = '/test';
+	const isAuthenticated = false;
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					path="/"
+					isAuthenticated={isAuthenticated}
+					component={App}
+				/>
+				<Login/>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent history={history}/>);
+
+	t.true(wrapper.text().includes('LOGIN'));
+});
+
+test('AuthenticatedRoute works for nested routes', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	history.location.pathname = '/dashboard/test';
+	const isAuthenticated = false;
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					path="/dashboard/:dashboardParams"
+					isAuthenticated={isAuthenticated}
+					component={App}
+				/>
+				<Login/>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent history={history}/>);
+
+	t.true(wrapper.text().includes('LOGIN'));
 });

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -48,8 +48,8 @@ test('allows access to specified path if authenticated', t => {
 			<div>
 				<AuthenticatedRoute
 					exact
-					path="/about"
 					isAuthenticated
+					path="/about"
 					component={App}
 				/>
 				<Login/>

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -62,7 +62,7 @@ test('allows access to specified path if authenticated', t => {
 	t.true(wrapper.text().includes('ABOUT'));
 });
 
-test('redirects to /login if not authenticated', t => {
+test('redirects to `/login` if not authenticated', t => {
 	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/test';
 	const BrowserComponent = props => (
@@ -158,7 +158,7 @@ test('AuthenticatedRoute allows access to nested routes in nested routing', t =>
 	t.true(wrapper.text().includes('DASHBOARD MAIN'));
 });
 
-test('AuthenticatedRoute matchPath positive allows access to loginPath as nested route', t => {
+test('AuthenticatedRoute `matchPath` positive allows access to `loginPath` as nested route', t => {
 	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/dashboard/login';
 	const BrowserComponent = props => (

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -41,16 +41,15 @@ test('accepts custom history object', t => {
 });
 
 test('allows access to specified path if authenticated', t => {
-	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/about';
-	const isAuthenticated = true;
 	const BrowserComponent = props => (
 		<BrowserRouter {...props}>
 			<div>
 				<AuthenticatedRoute
 					exact
 					path="/about"
-					isAuthenticated={isAuthenticated}
+					isAuthenticated
 					component={App}
 				/>
 				<Login/>
@@ -64,16 +63,15 @@ test('allows access to specified path if authenticated', t => {
 });
 
 test('redirects to /login if not authenticated', t => {
-	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/test';
-	const isAuthenticated = false;
 	const BrowserComponent = props => (
 		<BrowserRouter {...props}>
 			<div>
 				<AuthenticatedRoute
 					exact
 					path="/"
-					isAuthenticated={isAuthenticated}
+					isAuthenticated={false}
 					component={App}
 				/>
 				<Login/>
@@ -87,16 +85,15 @@ test('redirects to /login if not authenticated', t => {
 });
 
 test('AuthenticatedRoute works for nested routes', t => {
-	const {BrowserRouter, AuthenticatedRoute, history} = require('../index');
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/dashboard/test';
-	const isAuthenticated = false;
 	const BrowserComponent = props => (
 		<BrowserRouter {...props}>
 			<div>
 				<AuthenticatedRoute
 					exact
 					path="/dashboard/:dashboardParams"
-					isAuthenticated={isAuthenticated}
+					isAuthenticated={false}
 					component={App}
 				/>
 				<Login/>

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,9 +1,9 @@
 import test from 'ava';
 import React from 'react';
-import {Route} from 'react-router-dom';
+import {Route, Switch} from 'react-router-dom';
 import {createBrowserHistory} from 'history';
 import {render, mount} from 'enzyme';
-import {App, Login} from './fixtures/app';
+import {App, Login, DashboardMain} from './fixtures/app';
 
 test('creates a browser history', t => {
 	const {history} = require('../index');
@@ -57,7 +57,7 @@ test('allows access to specified path if authenticated', t => {
 		</BrowserRouter>
 	);
 
-	const wrapper = mount(<BrowserComponent history={history}/>);
+	const wrapper = mount(<BrowserComponent/>);
 
 	t.true(wrapper.text().includes('ABOUT'));
 });
@@ -79,12 +79,12 @@ test('redirects to /login if not authenticated', t => {
 		</BrowserRouter>
 	);
 
-	const wrapper = mount(<BrowserComponent history={history}/>);
+	const wrapper = mount(<BrowserComponent/>);
 
 	t.true(wrapper.text().includes('LOGIN'));
 });
 
-test('AuthenticatedRoute works for nested routes', t => {
+test('AuthenticatedRoute login redirect works for nested routes', t => {
 	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
 	history.location.pathname = '/dashboard/test';
 	const BrowserComponent = props => (
@@ -101,7 +101,59 @@ test('AuthenticatedRoute works for nested routes', t => {
 		</BrowserRouter>
 	);
 
-	const wrapper = mount(<BrowserComponent history={history}/>);
+	const wrapper = mount(<BrowserComponent/>);
 
 	t.true(wrapper.text().includes('LOGIN'));
+});
+
+test('AuthenticatedRoute redirects to Login for nested routes in nested routing', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
+	history.location.pathname = '/dashboard/main';
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					path="/dashboard/:dashboardParams"
+					isAuthenticated={false}
+					component={App}
+				>
+					<Switch>
+						<DashboardMain/>
+					</Switch>
+				</AuthenticatedRoute>
+				<Login/>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent/>);
+
+	t.true(wrapper.text().includes('LOGIN'));
+});
+
+test('AuthenticatedRoute allows access to nested routes in nested routing', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
+	history.location.pathname = '/dashboard/main';
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					isAuthenticated
+					path="/dashboard/:dashboardParams"
+					component={App}
+				>
+					<Switch>
+						<DashboardMain/>
+					</Switch>
+				</AuthenticatedRoute>
+				<Login/>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent/>);
+
+	t.true(wrapper.text().includes('DASHBOARD MAIN'));
 });

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {Route, Switch} from 'react-router-dom';
 import {createBrowserHistory} from 'history';
 import {render, mount} from 'enzyme';
-import {App, Login, DashboardMain} from './fixtures/app';
+import {App, Login, DashboardLogin, DashboardMain} from './fixtures/app';
 
 test('creates a browser history', t => {
 	const {history} = require('../index');
@@ -156,4 +156,28 @@ test('AuthenticatedRoute allows access to nested routes in nested routing', t =>
 	const wrapper = mount(<BrowserComponent/>);
 
 	t.true(wrapper.text().includes('DASHBOARD MAIN'));
+});
+
+test('AuthenticatedRoute matchPath positive allows access to loginPath as nested route', t => {
+	const {BrowserRouter, AuthenticatedRoute, history} = require('../');
+	history.location.pathname = '/dashboard/login';
+	const BrowserComponent = props => (
+		<BrowserRouter {...props}>
+			<div>
+				<AuthenticatedRoute
+					exact
+					isAuthenticated={false}
+					path="/dashboard/:dashboardParams"
+					loginPath="/dashboard/login"
+				>
+					<DashboardMain/>
+					<DashboardLogin/>
+				</AuthenticatedRoute>
+			</div>
+		</BrowserRouter>
+	);
+
+	const wrapper = mount(<BrowserComponent/>);
+
+	t.true(wrapper.text().includes('DASHBOARD LOGIN'));
 });

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -8,7 +8,7 @@ export const App = () => (
 	</>
 );
 
-export const Login = () => console.log('lelele') || (
+export const Login = () => (
 	<Route exact path="/login" component={() => <div>LOGIN</div>}/>
 );
 
@@ -16,6 +16,6 @@ export const DashboardMain = () => (
 	<Route exact path="/dashboard/main" component={() => <div>DASHBOARD MAIN</div>}/>
 );
 
-export const DashboardLogin = () => console.log('here') || (
+export const DashboardLogin = () => (
 	<Route exact path="/dashboard/login" component={() => <div>DASHBOARD LOGIN</div>}/>
 );

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -11,3 +11,7 @@ export const App = () => (
 export const Login = () => (
 	<Route exact path="/login" component={() => <div>LOGIN</div>}/>
 );
+
+export const DashboardMain = () => (
+	<Route exact path="/dashboard/main" component={() => <div>DASHBOARD MAIN</div>}/>
+);

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -8,10 +8,14 @@ export const App = () => (
 	</>
 );
 
-export const Login = () => (
+export const Login = () => console.log('lelele') || (
 	<Route exact path="/login" component={() => <div>LOGIN</div>}/>
 );
 
 export const DashboardMain = () => (
 	<Route exact path="/dashboard/main" component={() => <div>DASHBOARD MAIN</div>}/>
+);
+
+export const DashboardLogin = () => console.log('here') || (
+	<Route exact path="/dashboard/login" component={() => <div>DASHBOARD LOGIN</div>}/>
 );

--- a/test/fixtures/app.js
+++ b/test/fixtures/app.js
@@ -7,3 +7,7 @@ export const App = () => (
 		<Route path="/about" component={() => <div>ABOUT</div>}/>
 	</>
 );
+
+export const Login = () => (
+	<Route exact path="/login" component={() => <div>LOGIN</div>}/>
+);


### PR DESCRIPTION
- Used matchPath (https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md) from react-router-dom to make AuthenticatedRoute work with nested routes;
- Created tests for AuthenticatedRoute scenarios (authenticated, not authenticated, and not authenticated on nested routes);

Fixes #3

PS: When everything is complete, I would like to also include some documentation regarding AuthenticatedRoute for nested routes (https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/matchPath.md)


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3: Make `<AuthenticatedRoute/>` work in nested routes](https://issuehunt.io/repos/117250740/issues/3)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->